### PR TITLE
fix: retry if coveralls return 520

### DIFF
--- a/src/coveralls.erl
+++ b/src/coveralls.erl
@@ -118,7 +118,7 @@ send(Json, #s{poster=Poster, poster_init=Init} = S, AttemptsLeft) ->
   case ReturnCode of
     200      ->
       ok;
-    502 ->
+    _ when ReturnCode == 502; ReturnCode == 520 ->
       case AttemptsLeft > 0 of
         true -> timer:sleep(1_000), send(Json, S, AttemptsLeft - 1);
         false -> throw({error, {ReturnCode, Message}})


### PR DESCRIPTION
Example:
https://github.com/emqx/emqx/actions/runs/12127384437/job/33811975013?pr=14321#step:8:2065

```erlang
coveralls returns: {ok,{{"HTTP/1.1",520,[]}, %% ...
```