### PR TITLE
feat: retry any 5xx error

### DIFF
--- a/src/coveralls.erl
+++ b/src/coveralls.erl
@@ -118,7 +118,7 @@ send(Json, #s{poster=Poster, poster_init=Init} = S, AttemptsLeft) ->
   case ReturnCode of
     200      ->
       ok;
-    _ when ReturnCode == 502; ReturnCode == 520 ->
+    _ when 500 =< ReturnCode andalso ReturnCode < 600 ->
       case AttemptsLeft > 0 of
         true -> timer:sleep(1_000), send(Json, S, AttemptsLeft - 1);
         false -> throw({error, {ReturnCode, Message}})


### PR DESCRIPTION
Apparently, coveralls returns "random" 5xx status codes, like 520, [526](https://github.com/emqx/emqx/actions/runs/12910818200/job/36002341181?pr=14459#step:7:2111), ...